### PR TITLE
add link from blog to tag page

### DIFF
--- a/app/templates/post.hbs
+++ b/app/templates/post.hbs
@@ -1,2 +1,5 @@
 <h1>{{@model.title}}</h1>
 <p>{{@model.content}}</p>
+
+<h2>Primary Tag</h2>
+<LinkTo @route="tag" @model={{@model.tag}}>{{@model.tag.title}}</LinkTo>


### PR DESCRIPTION
This PR introduces a bug in the application that I think is caused by something in ember-data.

Essentially every `post` has a **single** tag associated with it, which is mapped out using a `belongsTo()` relationship.

## What I expect: 

I expect the link to work normally passing the `tag` relationship to the `<LinkTo />`

```
<LinkTo @route="tag" @model={{@model.tag}}>{{@model.tag.title}}</LinkTo>
```

## What actually happens: 

Error in the console: 

```
Uncaught Error: Assertion Failed: You attempted to generate a link for the "tag" route, but did not pass the models required for generating its dynamic segments. You must provide param `id` to `generate`.
```

## Recreation

- Visit the preview link for this PR https://deploy-preview-1--agitated-galileo-a26b5c.netlify.app/
- click any one of the blog links on the first page